### PR TITLE
[WIP] Error case refactoring

### DIFF
--- a/bson-numpy/bsonnumpy.c
+++ b/bson-numpy/bsonnumpy.c
@@ -603,7 +603,9 @@ _load_flexible_from_bson(bson_t *document, npy_intp *coordinates,
                         return 0;
                     }
                 } else {
-                    /* TODO: nicer error message */
+                    char buffer [100];
+                    snprintf(buffer, 100, "Could not find key \"%s\" in document %s\n", key_str, bson_as_json(document, NULL));
+                    debug(buffer, NULL);
                     PyErr_SetString(BsonNumpyError,
                                     "document does not match dtype.");
                     return 0;

--- a/bson-numpy/bsonnumpy.c
+++ b/bson-numpy/bsonnumpy.c
@@ -735,6 +735,11 @@ sequence_to_ndarray(PyObject *self, PyObject *args)
                         "dtype argument was invalid");
         return NULL;
     }
+    if (num_documents < 0) {
+        PyErr_SetString(BsonNumpyError,
+                        "count argument was negative");
+        return NULL;
+    }
 
     dimension_lengths = malloc(1 * sizeof(npy_intp));
     dimension_lengths[0] = num_documents;

--- a/bson-numpy/bsonnumpy.c
+++ b/bson-numpy/bsonnumpy.c
@@ -873,9 +873,9 @@ sequence_to_ndarray(PyObject *self, PyObject *args)
     if (row < num_documents) {
         PyObject *none_obj;
         PyArray_Dims newshape = {dimension_lengths, number_dimensions};
-//        if (debug_mode) {
+        if (debug_mode) {
             printf("resizing from %d to %d\n", num_documents, row);
-//        }
+        }
 
         dimension_lengths[0] = row;
         /* returns None or NULL */
@@ -945,7 +945,7 @@ initbsonnumpy(void)
     BsonNumpyError = PyErr_NewException("bsonnumpy.error", NULL, NULL);
     Py_INCREF(BsonNumpyError);
     PyModule_AddObject(m, "error", BsonNumpyError);
-    debug_mode = (NULL != getenv("BSON_NUMPY_DEBUG"));
+    debug_mode = (NULL != getenv("BSON_NUMPY_DEBUG")); // TODO: never set
 
     import_array();
 }

--- a/bson-numpy/bsonnumpy.c
+++ b/bson-numpy/bsonnumpy.c
@@ -592,11 +592,12 @@ _load_flexible_from_bson(bson_t *document, npy_intp *coordinates,
 
                     sub_coordinates[sub_depth] = i;
 
-                    if (!_load_flexible_from_bson(sub_document, coordinates, ndarray,
-                                             sub_dtype, current_depth + 1, NULL,
-                                             sub_coordinates,
-                                             sub_coordinates_length + 1,
-                                             offset + offset_long)) {
+                    if (!_load_flexible_from_bson(
+                            sub_document, coordinates, ndarray,
+                            sub_dtype, current_depth + 1, NULL,
+                            sub_coordinates,
+                            sub_coordinates_length + 1,
+                            offset + offset_long)) {
                         /* error set by _load_flexible_from_bson */
                         return 0;
                     }
@@ -605,7 +606,8 @@ _load_flexible_from_bson(bson_t *document, npy_intp *coordinates,
 
                     char buffer [100];
                     snprintf(buffer, 100,
-                             "could not find key \"%s\" in sub document", key_str);
+                             "could not find key \"%s\" in sub document",
+                             key_str);
                     debug(buffer, NULL, document);
                     PyErr_SetString(
                             BsonNumpyError,
@@ -693,7 +695,12 @@ _load_flexible_from_bson(bson_t *document, npy_intp *coordinates,
             /* Loop through array and load sub-arrays */
             bson_iter_recurse(&bsonit, &sub_it);
             for (i = 0; i < length_long; i++) {
-                //TODO: error is happening because the type is never checked before calling load_scalar
+                /* TODO: refactor _load_flexible_type into load_doc/load_array
+                 * The type is never checked before calling load_scalar
+                 * and in this case we want to make sure that the bson document
+                 * matches the dtype. The work is started in the 'nested-fix'
+                 * branch.
+                 */
                 int success;
 
                 bson_iter_next(&sub_it);

--- a/bson-numpy/bsonnumpy.c
+++ b/bson-numpy/bsonnumpy.c
@@ -586,8 +586,9 @@ _load_flexible_from_bson(bson_t *document, npy_intp *coordinates,
                                              offset + offset_long);
 
                 } else {
-                    PyErr_SetString(BsonNumpyError,
-                                    "Error: expected key from dtype in document, not found");
+                    PyErr_SetString(
+                            BsonNumpyError,
+                            "Error: expected key from dtype in document, not found");
                 }
             } else {
                 /* If the current key's value is a leaf */
@@ -604,7 +605,9 @@ _load_flexible_from_bson(bson_t *document, npy_intp *coordinates,
                     }
                 } else {
                     char buffer [100];
-                    snprintf(buffer, 100, "Could not find key \"%s\" in document %s\n", key_str, bson_as_json(document, NULL));
+                    snprintf(buffer, 100,
+                             "Could not find key \"%s\" in document %s\n",
+                             key_str, bson_as_json(document, NULL));
                     debug(buffer, NULL);
                     PyErr_SetString(BsonNumpyError,
                                     "document does not match dtype.");

--- a/bson-numpy/bsonnumpy.c
+++ b/bson-numpy/bsonnumpy.c
@@ -813,8 +813,6 @@ sequence_to_ndarray(PyObject *self, PyObject *args)
     }
 
     if (NPY_FAIL == PyArray_OutputConverter(array_obj, &ndarray)) {
-        PyErr_SetString(BsonNumpyError,
-                        "ndarray initialization failed");
         debug("PyArray_OutputConverter failed with array object",
               array_obj, NULL);
         PyErr_SetString(BsonNumpyError,

--- a/bson-numpy/bsonnumpy.c
+++ b/bson-numpy/bsonnumpy.c
@@ -17,7 +17,7 @@ _load_scalar_from_bson(bson_iter_t *bsonit, PyArrayObject *ndarray, long offset,
                        npy_intp *coordinates, int current_depth,
                        PyArray_Descr *dtype);
 
-static bool debug_mode;
+static bool debug_mode = false;
 
 static void
 debug(char* message, PyObject* object, bson_t* doc)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -123,16 +123,19 @@ class TestToNdarray(unittest.TestCase):
                 self.compare_elements(exp[name], act[name],
                                       dtype=dtype.fields[name][0])
 
-    def make_mixed_collection_test(self, docs, dtype):
+    def get_cursor_sequence(self, docs):
         self.client.bsonnumpy_test.coll.delete_many({})
         self.client.bsonnumpy_test.coll.insert_many(docs)
         raw_coll = self.client.get_database(
             'bsonnumpy_test',
             codec_options=CodecOptions(document_class=RawBSONDocument)).coll
-        cursor = raw_coll.find()
+        return raw_coll
+
+    def make_mixed_collection_test(self, docs, dtype):
+        raw_coll = self.get_cursor_sequence(docs)
 
         ndarray = bsonnumpy.sequence_to_ndarray(
-            (doc.raw for doc in cursor), dtype, raw_coll.count())
+            (doc.raw for doc in raw_coll.find()), dtype, raw_coll.count())
         self.compare_results(np.dtype(dtype),
                              self.client.bsonnumpy_test.coll.find(),
                              ndarray)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -140,6 +140,7 @@ class TestToNdarray(unittest.TestCase):
                              self.client.bsonnumpy_test.coll.find(),
                              ndarray)
 
+
 def millis(delta):
     if hasattr(delta, 'total_seconds'):
         return delta.total_seconds() * 1000

--- a/test/test_arrays.py
+++ b/test/test_arrays.py
@@ -2,10 +2,10 @@ import bson
 import bsonnumpy
 import numpy as np
 
-from test import TestFromBSON
+from test import TestToNdarray
 
 
-class TestFromBSONArrays(TestFromBSON):
+class TestFromBSONArrays(TestToNdarray):
     def test_constant(self):
         document = bson.SON([("0", 99),
                              ("1", 88),

--- a/test/test_error_cases.py
+++ b/test/test_error_cases.py
@@ -2,11 +2,128 @@ import bson
 import bsonnumpy
 import numpy as np
 
-from test import TestToNdarray
+from test import client_context, TestToNdarray, unittest
+
 
 class TestSequenceToNdarray(TestToNdarray):
+    dtype = np.dtype([('x', np.int32), ('y', np.int32)])
+    docs = [{"x": i, "y": 10 - i} for i in range(10)]
+    if hasattr(unittest.TestCase, 'assertRaisesRegex'):
+        assertRaisesPattern = unittest.TestCase.assertRaisesRegex
+    else:
+        assertRaisesPattern = unittest.TestCase.assertRaisesRegexp
 
-    def test_mismatched_dtype(self):
-        docs = [{"x": i, "y": 10 - i} for i in range(10)]
-        dtype = np.dtype([('x', np.int32), ('y', np.int32)])
-        self.make_mixed_collection_test(docs, dtype)
+    def test_incorrect_arguments(self):
+        # Expects iterator, dtype, count
+
+        with self.assertRaisesPattern(TypeError, r'.'):
+            bsonnumpy.sequence_to_ndarray(None, None, None)
+
+        with self.assertRaisesPattern(TypeError, r'sequence_to_ndarray requires an iterator'):
+            bsonnumpy.sequence_to_ndarray(0, 0, 0)
+
+        with self.assertRaisesPattern(TypeError, r'sequence_to_ndarray requires a numpy.dtype'):
+            bsonnumpy.sequence_to_ndarray(self.docs, None, 10)
+            bsonnumpy.sequence_to_ndarray(self.dtype, self.docs, 10, 10)
+
+
+    @client_context.require_connected
+    def test_incorrect_sequence(self):
+
+        # Non-iterator sequence
+        with self.assertRaisesPattern(TypeError, r'sequence_to_ndarray requires an iterator'):
+            bsonnumpy.sequence_to_ndarray(None, self.dtype, 10)
+
+        # Empty iterator
+        for empty in [[], {}, ()]:
+            res = bsonnumpy.sequence_to_ndarray(empty, self.dtype, 10)
+            self.assertEqual(res.dtype, self.dtype)
+            self.assertEqual(res.size, 0)
+
+        # Non-BSON documents
+        # print bsonnumpy.sequence_to_ndarray(self.docs, self.dtype, 10)
+        # print bsonnumpy.sequence_to_ndarray(({} for _ in range(10)), self.dtype, 10)
+        # print bsonnumpy.sequence_to_ndarray((None for _ in range(10)), self.dtype, 10)
+
+
+        # Test iterator of invalid BSON
+
+    # def test_incorrect_dtype(self):
+    #     print bsonnumpy.sequence_to_ndarray(None, dtype, 10)
+    #     # Dtype is named, but does not match documents
+    #     # Dtype is not named
+    #     # Dtype is null or empty
+    #     pass
+    #
+    # def test_incorrect_count(self):
+    #     # Count is greater than iterator
+    #     # Count is smaller than iterator
+    #     # Count is negative
+    #     # Count is null
+    #     pass
+    #
+    # def test_sub_named_fields(self):
+    #     # dtype.fields is not a dict
+    #     # "expected list from dtype, got other type"
+    #     # "expected key from dtype in document, not found"
+    #     pass
+    #
+    # def test_named_scalar_load(self):
+    #     # within named dtype, scalar value has sub_dtype->elsize
+    #     # within named dtype, scalar value does not match dtype specificed key ("document does not match dtype")
+    #     pass
+    #
+    # def test_sub_array(self):
+    #     # dtype expects list, document does not contain array ("expected list from dtype, got another type")
+    #     # "expected subarray, got other type"
+    #     # "key from dtype not found"
+    #     pass
+    #
+    # def test_array_scalar_load(self):
+    #     # array within named dtype contains named dtype
+    #     # array within named dtype contains array
+    #     # TODO: unhandled case
+    #     pass
+
+    # def test_mismatched_dtype1(self):
+    #     docs = [{"x": [1, i ,3], "y": 10 - i} for i in range(10)]
+    #     dtype = np.dtype([('x', np.int32), ('y', np.int32)])
+    #
+    #     coll = self.get_cursor_sequence(docs)
+    #
+    #     bsonnumpy.sequence_to_ndarray(
+    #         (doc.raw for doc in coll.find()), dtype, coll.count())
+    #
+    # def test_mismatched_dtype1(self):
+    #     docs = [{"y": 10 - i} for i in range(10)]
+    #     dtype = np.dtype([('x', np.int32), ('y', np.int32)])
+    #
+    #     coll = self.get_cursor_sequence(docs)
+    #
+    #     bsonnumpy.sequence_to_ndarray(
+    #         (doc.raw for doc in coll.find()), dtype, coll.count())
+    #
+    # def test_unnamed_dtype(self):
+    #     docs = [{"y": 10 - i} for i in range(10)]
+    #     dtype = np.dtype('10int32')
+    #
+    #     coll = self.get_cursor_sequence(docs)
+    #
+    #     bsonnumpy.sequence_to_ndarray(
+    #         (doc.raw for doc in coll.find()), dtype, coll.count())
+    #
+    #
+    # def test_wrong_count(self):
+    #     docs = [{"x": i, "y": 10 - i} for i in range(10)]
+    #     dtype = np.dtype([('x', np.int32), ('y', np.int32)])
+    #
+    #     coll = self.get_cursor_sequence(docs)
+    #     ndarray = bsonnumpy.sequence_to_ndarray(
+    #         (doc.raw for doc in coll.find()), dtype, 8)
+    #     print ndarray
+    #
+    #
+    #     coll = self.get_cursor_sequence(docs)
+    #     ndarray = bsonnumpy.sequence_to_ndarray(
+    #         (doc.raw for doc in coll.find()), dtype, 12)
+    #     print ndarray

--- a/test/test_error_cases.py
+++ b/test/test_error_cases.py
@@ -228,6 +228,24 @@ class TestErrors(TestToNdarray):
                 "invalid document: expected list from dtype, got other type"):
             bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
 
+
+    @unittest.skip("not yet implemented")
+    def test_incorrect_sub_dtype2(self):
+        son_docs = [
+            bson.SON(
+                [("x", [[i, i*2, i*3], [i*4, i*5, i*6]]),
+                 ("y", [[i*7, i*8, i*9], [i*10, i*11, i*12]])])
+            for i in ['a', 'b', 'c', 'd']]
+        raw_docs = [bson._dict_to_bson(
+            doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
+
+        dtype = np.dtype([('x', '2,3S13'), ('y', '2,3S13')])
+
+        ndarray = np.array(
+            [([[i, i*2, i*3], [i*4, i*5, i*6]],
+              ([[i*7, i*8, i*9], [i*10, i*11, i*12]]))
+             for i in ['a', 'b', 'c', 'd']], dtype=dtype)
+
         # Top-level array too long
         bad_doc = bson.SON(
             [("x", [['d'*1, 'd'*2, 'd'*3],
@@ -253,23 +271,6 @@ class TestErrors(TestToNdarray):
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
         res = bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
         self.assertTrue(np.array_equal(ndarray, res))
-
-    @unittest.skip("not yet implemented")
-    def test_incorrect_sub_dtype2(self):
-        son_docs = [
-            bson.SON(
-                [("x", [[i, i*2, i*3], [i*4, i*5, i*6]]),
-                 ("y", [[i*7, i*8, i*9], [i*10, i*11, i*12]])])
-            for i in ['a', 'b', 'c', 'd']]
-        raw_docs = [bson._dict_to_bson(
-            doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
-
-        dtype = np.dtype([('x', '2,3S13'), ('y', '2,3S13')])
-
-        ndarray = np.array(
-            [([[i, i*2, i*3], [i*4, i*5, i*6]],
-              ([[i*7, i*8, i*9], [i*10, i*11, i*12]]))
-             for i in ['a', 'b', 'c', 'd']], dtype=dtype)
 
         # TODO: not checking type
         # Sub array not array

--- a/test/test_error_cases.py
+++ b/test/test_error_cases.py
@@ -1,0 +1,12 @@
+import bson
+import bsonnumpy
+import numpy as np
+
+from test import TestToNdarray
+
+class TestSequenceToNdarray(TestToNdarray):
+
+    def test_mismatched_dtype(self):
+        docs = [{"x": i, "y": 10 - i} for i in range(10)]
+        dtype = np.dtype([('x', np.int32), ('y', np.int32)])
+        self.make_mixed_collection_test(docs, dtype)

--- a/test/test_error_cases.py
+++ b/test/test_error_cases.py
@@ -120,7 +120,8 @@ class TestErrors(TestToNdarray):
              ("q", bson.SON([("y", 0), ("z", 0)]))])
 
         bad_raw_docs = raw_docs[:9]
-        bad_raw_docs.append(bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
+        bad_raw_docs.append(
+            bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
         with self.assertRaisesPattern(bsonnumpy.error,
                                       "document does not match dtype"):
@@ -132,7 +133,8 @@ class TestErrors(TestToNdarray):
              ("q", bson.SON([("y", 0), ("z", 0)]))])
 
         bad_raw_docs = raw_docs[:9]
-        bad_raw_docs.append(bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
+        bad_raw_docs.append(
+            bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
         with self.assertRaisesPattern(bsonnumpy.error,
                                       "document does not match dtype"):
@@ -144,11 +146,13 @@ class TestErrors(TestToNdarray):
              ("q", 10)])
 
         bad_raw_docs = raw_docs[:9]
-        bad_raw_docs.append(bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
+        bad_raw_docs.append(
+            bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
         with self.assertRaisesPattern(
                 bsonnumpy.error,
-                "invalid document: expected subdoc from dtype, got other type"):
+                "invalid document: expected subdoc from dtype,"
+                " got other type"):
             bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype_sub, 10)
 
         # Sub document not a document
@@ -157,19 +161,20 @@ class TestErrors(TestToNdarray):
              ("q", [10, 11, 12])])
 
         bad_raw_docs = raw_docs[:9]
-        bad_raw_docs.append(bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
+        bad_raw_docs.append(
+            bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
         with self.assertRaisesPattern(
                 bsonnumpy.error,
-                "invalid document: expected subdoc from dtype, got other type"):
+                "invalid document: expected subdoc from dtype,"
+                " got other type"):
             bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype_sub, 10)
 
         # Sub document extra key
         dtype2 = np.dtype([('y', np.int32), ('z', np.int32)])
         dtype_sub2 = np.dtype([('x', dtype2)])
 
-        ndarray2 = np.array([((i, i),) for i in range(10)],
-                           dtype=dtype_sub2)
+        ndarray2 = np.array([((i, i),) for i in range(10)], dtype=dtype_sub2)
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype_sub2, 10)
         self.assertTrue(np.array_equal(ndarray2, res))
 
@@ -185,7 +190,7 @@ class TestErrors(TestToNdarray):
             bson.SON(
                 [("x", [[i, i*2, i*3], [i*4, i*5, i*6]]),
                  ("y", [[i*7, i*8, i*9], [i*10, i*11, i*12]])])
-             for i in ['a', 'b', 'c', 'd']]
+            for i in ['a', 'b', 'c', 'd']]
         raw_docs = [bson._dict_to_bson(
             doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
         dtype = np.dtype([('x', '2,3S13'), ('y', '2,3S13')])
@@ -204,18 +209,19 @@ class TestErrors(TestToNdarray):
             [("x", [['d'*1, 'd'*2, 'd'*3], ['d'*4, 'd'*5, 'd'*6]]),
              ("bad_key", [['d'*7, 'd'*7, 'd'*9], ['d'*10, 'd'*11, 'd'*12]])])
         bad_raw_docs = raw_docs[:3]
-        bad_raw_docs.append(bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
+        bad_raw_docs.append(
+            bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
         with self.assertRaisesPattern(bsonnumpy.error,
                                       "document does not match dtype"):
-
-             bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
+            bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
 
         # Top-level array not array
         bad_doc = bson.SON(
             [("x", [['d'*1, 'd'*2, 'd'*3], ['d'*4, 'd'*5, 'd'*6]]),
              ("y", 'not an array')])
         bad_raw_docs = raw_docs[:3]
-        bad_raw_docs.append(bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
+        bad_raw_docs.append(
+            bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
         with self.assertRaisesPattern(
                 bsonnumpy.error,
@@ -224,33 +230,42 @@ class TestErrors(TestToNdarray):
 
         # Top-level array too long
         bad_doc = bson.SON(
-            [("x", [['d'*1, 'd'*2, 'd'*3], ['d'*4, 'd'*5, 'd'*6], ['d'*4, 'd'*5, 'd'*6]]),
-             ("y", [['d'*7, 'd'*8, 'd'*9], ['d'*10, 'd'*11, 'd'*12], ['d'*10, 'd'*11, 'd'*12]])])
+            [("x", [['d'*1, 'd'*2, 'd'*3],
+                    ['d'*4, 'd'*5, 'd'*6],
+                    ['d'*4, 'd'*5, 'd'*6]]),
+             ("y", [['d'*7, 'd'*8, 'd'*9],
+                    ['d'*10, 'd'*11, 'd'*12],
+                    ['d'*10, 'd'*11, 'd'*12]])])
         bad_raw_docs = raw_docs[:3]
-        bad_raw_docs.append(bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
+        bad_raw_docs.append(
+            bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
         res = bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
         self.assertTrue(np.array_equal(ndarray, res))
 
         # Sub array too long
         bad_doc = bson.SON(
-            [("x", [['d'*1, 'd'*2, 'd'*3, 'd'*3], ['d'*4, 'd'*5, 'd'*6, 'd'*3]]),
-             ("y", [['d'*7, 'd'*8, 'd'*9, 'd'*3], ['d'*10, 'd'*11, 'd'*12, 'd'*3]])])
+            [("x", [['d'*1, 'd'*2, 'd'*3, 'd'*3],
+                    ['d'*4, 'd'*5, 'd'*6, 'd'*3]]),
+             ("y", [['d'*7, 'd'*8, 'd'*9, 'd'*3],
+                    ['d'*10, 'd'*11, 'd'*12, 'd'*3]])])
         bad_raw_docs = raw_docs[:3]
-        bad_raw_docs.append(bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
+        bad_raw_docs.append(
+            bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
         res = bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
         self.assertTrue(np.array_equal(ndarray, res))
 
-        #TODO: not checking type
+        # TODO: not checking type
         # Sub array not array
         bad_doc = bson.SON(
             [("x", [['d'*1, 'd'*2, 'd'*3], ['d'*4, 'd'*5, 'd'*6]]),
              ("y", ['not an array', ['d'*10, 'd'*11, 'd'*12]])])
         bad_raw_docs = raw_docs[:3]
-        bad_raw_docs.append(bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
+        bad_raw_docs.append(
+            bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
         # with self.assertRaisesPattern(bsonnumpy.error,
         #                               "document does not match dtype"):
-        # print bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
+        # bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
 
         # TODO: segfaults
         # Top-level array too short
@@ -258,8 +273,9 @@ class TestErrors(TestToNdarray):
             [("x", [['d'*1, 'd'*2, 'd'*3]]),
              ("y", [['d'*7, 'd'*8, 'd'*9]])])
         bad_raw_docs = raw_docs[:3]
-        bad_raw_docs.append(bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
-        # print bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
+        bad_raw_docs.append(
+            bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
+        # bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
 
         # TODO: currently just leaves last element empty
         # Sub array too short
@@ -267,7 +283,7 @@ class TestErrors(TestToNdarray):
             [("x", [['d'*1, 'd'*2], ['d'*4, 'd'*5]]),
              ("y", [['d'*7, 'd'*8], ['d'*10, 'd'*11]])])
         bad_raw_docs = raw_docs[:3]
-        bad_raw_docs.append(bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
-        res = bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
+        bad_raw_docs.append(
+            bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
+        # res = bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
         # self.assertTrue(np.array_equal(ndarray, res))
-

--- a/test/test_error_cases.py
+++ b/test/test_error_cases.py
@@ -5,7 +5,7 @@ import numpy as np
 from test import client_context, TestToNdarray, unittest
 
 
-class TestSequenceToNdarray(TestToNdarray):
+class TestErrors(TestToNdarray):
     dtype = np.dtype([('x', np.int32), ('y', np.int32)])
     docs = [{"x": i, "y": 10 - i} for i in range(10)]
     if hasattr(unittest.TestCase, 'assertRaisesRegex'):
@@ -18,12 +18,11 @@ class TestSequenceToNdarray(TestToNdarray):
 
         with self.assertRaisesPattern(TypeError, r'.'):
             bsonnumpy.sequence_to_ndarray(None, None, None)
-
         with self.assertRaisesPattern(TypeError, r'sequence_to_ndarray requires an iterator'):
             bsonnumpy.sequence_to_ndarray(0, 0, 0)
-
         with self.assertRaisesPattern(TypeError, r'sequence_to_ndarray requires a numpy.dtype'):
             bsonnumpy.sequence_to_ndarray(self.docs, None, 10)
+        with self.assertRaisesPattern(TypeError, r'function takes exactly 3 arguments \(4 given\)'):
             bsonnumpy.sequence_to_ndarray(self.dtype, self.docs, 10, 10)
 
 
@@ -41,12 +40,13 @@ class TestSequenceToNdarray(TestToNdarray):
             self.assertEqual(res.size, 0)
 
         # Non-BSON documents
-        # print bsonnumpy.sequence_to_ndarray(self.docs, self.dtype, 10)
-        # print bsonnumpy.sequence_to_ndarray(({} for _ in range(10)), self.dtype, 10)
-        # print bsonnumpy.sequence_to_ndarray((None for _ in range(10)), self.dtype, 10)
+        with self.assertRaisesPattern(bsonnumpy.error, r'document from sequence failed validation'):
+            bsonnumpy.sequence_to_ndarray(self.docs, self.dtype, 10)
+        with self.assertRaisesPattern(bsonnumpy.error, r'document from sequence failed validation'):
+            bsonnumpy.sequence_to_ndarray((None for _ in range(10)), self.dtype, 10)
+        with self.assertRaisesPattern(bsonnumpy.error, r'document from sequence failed validation'):
+            bsonnumpy.sequence_to_ndarray(({} for _ in range(10)), self.dtype, 10)
 
-
-        # Test iterator of invalid BSON
 
     # def test_incorrect_dtype(self):
     #     print bsonnumpy.sequence_to_ndarray(None, dtype, 10)

--- a/test/test_error_cases.py
+++ b/test/test_error_cases.py
@@ -48,13 +48,27 @@ class TestErrors(TestToNdarray):
             bsonnumpy.sequence_to_ndarray(({} for _ in range(10)), self.dtype, 10)
 
 
-    # def test_incorrect_dtype(self):
-    #     print bsonnumpy.sequence_to_ndarray(None, dtype, 10)
-    #     # Dtype is named, but does not match documents
-    #     # Dtype is not named
-    #     # Dtype is null or empty
-    #     pass
-    #
+    def test_incorrect_dtype(self):
+        document = bson.SON([("x", 99),
+                             ("y", 88)])
+        utf8 = bson._dict_to_bson(document, False, bson.DEFAULT_CODEC_OPTIONS)
+        dtype = np.dtype([('a', np.int32), ('b', np.int32)])
+
+        # Dtype is named, but does not match documents
+        with self.assertRaisesPattern(bsonnumpy.error, r'document does not match dtype'):
+            bsonnumpy.sequence_to_ndarray([utf8], dtype, 1)
+
+        # Dtype is not named
+        with self.assertRaisesPattern(bsonnumpy.error, r'dtype must include field names, like dtype\(\[\(\'fieldname\', numpy.int\)\]\)'):
+            bsonnumpy.sequence_to_ndarray([utf8], np.dtype(np.int32), 1)
+
+        # Dtype is null or empty
+        with self.assertRaisesPattern(TypeError, r'sequence_to_ndarray requires a numpy.dtype'):
+            bsonnumpy.sequence_to_ndarray([utf8], None, 1)
+
+
+
+
     # def test_incorrect_count(self):
     #     # Count is greater than iterator
     #     # Count is smaller than iterator

--- a/test/test_error_cases.py
+++ b/test/test_error_cases.py
@@ -254,6 +254,23 @@ class TestErrors(TestToNdarray):
         res = bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
         self.assertTrue(np.array_equal(ndarray, res))
 
+    @unittest.skip("not yet implemented")
+    def test_incorrect_sub_dtype2(self):
+        son_docs = [
+            bson.SON(
+                [("x", [[i, i*2, i*3], [i*4, i*5, i*6]]),
+                 ("y", [[i*7, i*8, i*9], [i*10, i*11, i*12]])])
+            for i in ['a', 'b', 'c', 'd']]
+        raw_docs = [bson._dict_to_bson(
+            doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
+
+        dtype = np.dtype([('x', '2,3S13'), ('y', '2,3S13')])
+
+        ndarray = np.array(
+            [([[i, i*2, i*3], [i*4, i*5, i*6]],
+              ([[i*7, i*8, i*9], [i*10, i*11, i*12]]))
+             for i in ['a', 'b', 'c', 'd']], dtype=dtype)
+
         # TODO: not checking type
         # Sub array not array
         bad_doc = bson.SON(
@@ -263,9 +280,9 @@ class TestErrors(TestToNdarray):
         bad_raw_docs.append(
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
-        # with self.assertRaisesPattern(bsonnumpy.error,
-        #                               "document does not match dtype"):
-        # bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
+        with self.assertRaisesPattern(bsonnumpy.error,
+                                      "document does not match dtype"):
+            bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
 
         # TODO: segfaults
         # Top-level array too short
@@ -275,7 +292,10 @@ class TestErrors(TestToNdarray):
         bad_raw_docs = raw_docs[:3]
         bad_raw_docs.append(
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
-        # bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
+
+        with self.assertRaisesPattern(bsonnumpy.error,
+                                      "document does not match dtype"):
+            bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
 
         # TODO: currently just leaves last element empty
         # Sub array too short
@@ -285,5 +305,5 @@ class TestErrors(TestToNdarray):
         bad_raw_docs = raw_docs[:3]
         bad_raw_docs.append(
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
-        # res = bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
-        # self.assertTrue(np.array_equal(ndarray, res))
+        res = bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
+        self.assertTrue(np.array_equal(ndarray, res))

--- a/test/test_error_cases.py
+++ b/test/test_error_cases.py
@@ -8,8 +8,8 @@ from test import client_context, TestToNdarray, unittest
 class TestErrors(TestToNdarray):
     dtype = np.dtype([('x', np.int32), ('y', np.int32)])
     bson_docs = [bson._dict_to_bson(
-        doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in [bson.SON(
-        [("x", i), ("y", -i)]) for i in range(10)]]
+        doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in [
+        bson.SON([("x", i), ("y", -i)]) for i in range(10)]]
     ndarray = np.array([(i, -i) for i in range(10)], dtype=dtype)
     if hasattr(unittest.TestCase, 'assertRaisesRegex'):
         assertRaisesPattern = unittest.TestCase.assertRaisesRegex
@@ -33,8 +33,6 @@ class TestErrors(TestToNdarray):
                 TypeError, r'function takes exactly 3 arguments \(4 given\)'):
             bsonnumpy.sequence_to_ndarray(self.dtype, self.bson_docs, 10, 10)
 
-
-    @client_context.require_connected
     def test_incorrect_sequence(self):
         docs = [{"x": i, "y": -i} for i in range(10)]
 
@@ -62,7 +60,6 @@ class TestErrors(TestToNdarray):
             bsonnumpy.sequence_to_ndarray(
                 ({} for _ in range(10)), self.dtype, 10)
 
-
     def test_incorrect_dtype(self):
         dtype = np.dtype([('a', np.int32), ('b', np.int32)])
 
@@ -74,7 +71,8 @@ class TestErrors(TestToNdarray):
         # Dtype is not named
         with self.assertRaisesPattern(
                 bsonnumpy.error,
-                r'dtype must include field names, like dtype\(\[\(\'fieldname\', numpy.int\)\]\)'):
+                r'dtype must include field names,'
+                r' like dtype\(\[\(\'fieldname\', numpy.int\)\]\)'):
             bsonnumpy.sequence_to_ndarray(
                 self.bson_docs, np.dtype(np.int32), 10)
 
@@ -82,7 +80,6 @@ class TestErrors(TestToNdarray):
         with self.assertRaisesPattern(
                 TypeError, r'sequence_to_ndarray requires a numpy.dtype'):
             bsonnumpy.sequence_to_ndarray(self.bson_docs, None, 1)
-
 
     def test_incorrect_count(self):
         self.assertTrue(
@@ -99,7 +96,6 @@ class TestErrors(TestToNdarray):
         with self.assertRaisesPattern(TypeError, r'\binteger\b'):
             bsonnumpy.sequence_to_ndarray(self.bson_docs, self.dtype, None)
 
-
     # def test_sub_named_fields(self):
     #     # dtype.fields is not a dict
     #     # "expected list from dtype, got other type"
@@ -108,11 +104,13 @@ class TestErrors(TestToNdarray):
     #
     # def test_named_scalar_load(self):
     #     # within named dtype, scalar value has sub_dtype->elsize
-    #     # within named dtype, scalar value does not match dtype specificed key ("document does not match dtype")
+    #     # within named dtype, scalar value does not match dtype specificed
+            # key ("document does not match dtype")
     #     pass
     #
     # def test_sub_array(self):
-    #     # dtype expects list, document does not contain array ("expected list from dtype, got another type")
+    #     # dtype expects list, document does not contain array ("expected list
+            #  from dtype, got another type")
     #     # "expected subarray, got other type"
     #     # "key from dtype not found"
     #     pass

--- a/test/test_nested.py
+++ b/test/test_nested.py
@@ -16,6 +16,7 @@ class TestNested(TestToNdarray):
     else:
         assertRaisesPattern = unittest.TestCase.assertRaisesRegexp
 
+    @unittest.skip("not yet implemented")
     def test_array_scalar_load1(self):
         # Test arrays with documents as elements
 
@@ -40,6 +41,7 @@ class TestNested(TestToNdarray):
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)
         self.assertTrue(np.array_equal(ndarray, res))
 
+    @unittest.skip("not yet implemented")
     def test_array_scalar_load2(self):
         # Test sub arrays with documents as elements
         son_docs = [
@@ -73,6 +75,7 @@ class TestNested(TestToNdarray):
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)
         self.assertTrue(np.array_equal(ndarray, res))
 
+    @unittest.skip("not yet implemented")
     def test_array_scalar_load3(self):
         # Test sub arrays with documents that have arrays
         son_docs = [
@@ -101,6 +104,7 @@ class TestNested(TestToNdarray):
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)
         self.assertTrue(np.array_equal(ndarray, res))
 
+    @unittest.skip("not yet implemented")
     def test_array_scalar_load4(self):
         # Test documents with multiple levels of sub documents
         son_docs = [

--- a/test/test_nested.py
+++ b/test/test_nested.py
@@ -1,0 +1,138 @@
+import bson
+import bsonnumpy
+import numpy as np
+
+from test import client_context, TestToNdarray, unittest
+
+
+class TestNested(TestToNdarray):
+    dtype = np.dtype([('x', np.int32), ('y', np.int32)])
+    bson_docs = [bson._dict_to_bson(
+        doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in [
+                     bson.SON([("x", i), ("y", -i)]) for i in range(10)]]
+    ndarray = np.array([(i, -i) for i in range(10)], dtype=dtype)
+    if hasattr(unittest.TestCase, 'assertRaisesRegex'):
+        assertRaisesPattern = unittest.TestCase.assertRaisesRegex
+    else:
+        assertRaisesPattern = unittest.TestCase.assertRaisesRegexp
+
+    def test_array_scalar_load1(self):
+        # Test arrays with documents as elements
+
+        son_docs = [
+            bson.SON(
+                [('x', [
+                    bson.SON([('a', i), ('b', i)]),
+                    bson.SON([('a', -i), ('b', -i)])
+                ])]) for i in range(10)]
+        raw_docs = [bson._dict_to_bson(
+            doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
+        sub_dtype = np.dtype(([('a', 'int32'), ('b', 'int32')], 2))
+        dtype = np.dtype([('x', sub_dtype)])
+
+        ndarray = np.array([
+                               ([(i, i), (-i, -i)],)
+                               for i in range(10)], dtype)
+
+        print ndarray
+
+        # Correct dtype
+        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)
+        self.assertTrue(np.array_equal(ndarray, res))
+
+    def test_array_scalar_load2(self):
+        # Test sub arrays with documents as elements
+        son_docs = [
+            bson.SON(
+                [('x', [
+                    [
+                        bson.SON([('a', i), ('b', i)]),
+                        bson.SON([('a', -i), ('b', -i)])
+                    ],
+                    [
+                        bson.SON([('c', i), ('d', i)]),
+                        bson.SON([('c', -i), ('d', -i)])
+                    ],
+
+                ])]) for i in range(10)]
+        raw_docs = [bson._dict_to_bson(
+            doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
+        sub_sub_dtype = np.dtype(([('a', 'int32'), ('b', 'int32')], 2))
+        sub_dtype = np.dtype((sub_sub_dtype, 2))
+        dtype = np.dtype([('x', sub_dtype)])
+
+        ndarray = np.array([
+                               [
+                                   ([(i, i), (-i, -i)],),
+                                   ([(i, i), (-i, -i)],)
+                               ] for i in range(10)], dtype)
+
+        print ndarray
+
+        # Correct dtype
+        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)
+        self.assertTrue(np.array_equal(ndarray, res))
+
+    def test_array_scalar_load3(self):
+        # Test sub arrays with documents that have arrays
+        son_docs = [
+            bson.SON(
+                [('x', [
+                    bson.SON([('a', [i, i, i, i]), ('b', [i, i, i, i])]),
+                    bson.SON([('a', [-i, -i -i, -i]), ('b', [-i, -i, -i, -i])])
+                ])]) for i in range(10)]
+
+        raw_docs = [bson._dict_to_bson(
+            doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
+        sub_dtype = np.dtype(([('a', '4int32'), ('b', '4int32')], 2))
+        dtype = np.dtype([('x', sub_dtype)])
+
+        ndarray = np.array([
+                               ([(
+                                   [i, i, i, i], [i, i, i, i]
+                               ), (
+                                   [-i, -i, -i, -i], [-i, -i, -i, -i]
+                               )],)
+                               for i in range(10)], dtype)
+
+        print ndarray
+
+        # Correct dtype
+        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)
+        self.assertTrue(np.array_equal(ndarray, res))
+
+    def test_array_scalar_load4(self):
+        # Test documents with multiple levels of sub documents
+        son_docs = [
+            bson.SON(
+                [('x', [
+                    [
+                        bson.SON([('a', i), ('b', i)]),
+                        bson.SON([('a', -i), ('b', -i)])
+                    ],
+                    [
+                        bson.SON([('c', i), ('d', i)]),
+                        bson.SON([('c', -i), ('d', -i)])
+                    ],
+
+                ])]) for i in range(10)]
+        raw_docs = [bson._dict_to_bson(
+            doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
+        sub_sub_sub_dtype = np.dtype([('q', 'int32')])
+        sub_sub_dtype = np.dtype(([('a', sub_sub_sub_dtype), ('b', sub_sub_sub_dtype)], 2))
+        sub_dtype = np.dtype((sub_sub_dtype, 2))
+        dtype = np.dtype([('x', sub_dtype)])
+
+        print dtype
+
+        print np.zeros(1, dtype)
+
+        ndarray = np.array([
+                               ([[((i,), (i,)), ((-i,), (-i,))], [((i,), (i,)), ((-i,), (-i,))]],)
+                               for i in range(10)], dtype)
+
+        print ndarray
+
+        # Correct dtype
+        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)
+        self.assertTrue(np.array_equal(ndarray, res))

--- a/test/test_nested.py
+++ b/test/test_nested.py
@@ -9,7 +9,7 @@ class TestNested(TestToNdarray):
     dtype = np.dtype([('x', np.int32), ('y', np.int32)])
     bson_docs = [bson._dict_to_bson(
         doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in [
-                     bson.SON([("x", i), ("y", -i)]) for i in range(10)]]
+        bson.SON([("x", i), ("y", -i)]) for i in range(10)]]
     ndarray = np.array([(i, -i) for i in range(10)], dtype=dtype)
     if hasattr(unittest.TestCase, 'assertRaisesRegex'):
         assertRaisesPattern = unittest.TestCase.assertRaisesRegex
@@ -31,12 +31,7 @@ class TestNested(TestToNdarray):
         sub_dtype = np.dtype(([('a', 'int32'), ('b', 'int32')], 2))
         dtype = np.dtype([('x', sub_dtype)])
 
-        ndarray = np.array([
-                               ([(i, i), (-i, -i)],)
-                               for i in range(10)], dtype)
-
-        print ndarray
-
+        ndarray = np.array([([(i, i), (-i, -i)],) for i in range(10)], dtype)
         # Correct dtype
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)
         self.assertTrue(np.array_equal(ndarray, res))
@@ -63,13 +58,8 @@ class TestNested(TestToNdarray):
         sub_dtype = np.dtype((sub_sub_dtype, 2))
         dtype = np.dtype([('x', sub_dtype)])
 
-        ndarray = np.array([
-                               [
-                                   ([(i, i), (-i, -i)],),
-                                   ([(i, i), (-i, -i)],)
-                               ] for i in range(10)], dtype)
-
-        print ndarray
+        ndarray = np.array([[([(i, i), (-i, -i)],),
+                             ([(i, i), (-i, -i)],)] for i in range(10)], dtype)
 
         # Correct dtype
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)
@@ -81,8 +71,10 @@ class TestNested(TestToNdarray):
         son_docs = [
             bson.SON(
                 [('x', [
-                    bson.SON([('a', [i, i, i, i]), ('b', [i, i, i, i])]),
-                    bson.SON([('a', [-i, -i -i, -i]), ('b', [-i, -i, -i, -i])])
+                    bson.SON([('a', [i, i, i, i]),
+                              ('b', [i, i, i, i])]),
+                    bson.SON([('a', [-i, -i, -i, -i]),
+                              ('b', [-i, -i, -i, -i])])
                 ])]) for i in range(10)]
 
         raw_docs = [bson._dict_to_bson(
@@ -90,15 +82,10 @@ class TestNested(TestToNdarray):
         sub_dtype = np.dtype(([('a', '4int32'), ('b', '4int32')], 2))
         dtype = np.dtype([('x', sub_dtype)])
 
-        ndarray = np.array([
-                               ([(
-                                   [i, i, i, i], [i, i, i, i]
-                               ), (
-                                   [-i, -i, -i, -i], [-i, -i, -i, -i]
-                               )],)
-                               for i in range(10)], dtype)
-
-        print ndarray
+        ndarray = np.array(
+            [([([i, i, i, i], [i, i, i, i]),
+               ([-i, -i, -i, -i], [-i, -i, -i, -i])],)
+             for i in range(10)], dtype)
 
         # Correct dtype
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)
@@ -123,19 +110,14 @@ class TestNested(TestToNdarray):
         raw_docs = [bson._dict_to_bson(
             doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
         sub_sub_sub_dtype = np.dtype([('q', 'int32')])
-        sub_sub_dtype = np.dtype(([('a', sub_sub_sub_dtype), ('b', sub_sub_sub_dtype)], 2))
+        sub_sub_dtype = np.dtype(
+            ([('a', sub_sub_sub_dtype), ('b', sub_sub_sub_dtype)], 2))
         sub_dtype = np.dtype((sub_sub_dtype, 2))
         dtype = np.dtype([('x', sub_dtype)])
 
-        print dtype
-
-        print np.zeros(1, dtype)
-
-        ndarray = np.array([
-                               ([[((i,), (i,)), ((-i,), (-i,))], [((i,), (i,)), ((-i,), (-i,))]],)
-                               for i in range(10)], dtype)
-
-        print ndarray
+        ndarray = np.array([([[((i,), (i,)), ((-i,), (-i,))],
+                              [((i,), (i,)), ((-i,), (-i,))]],)
+                            for i in range(10)], dtype)
 
         # Correct dtype
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)

--- a/test/test_scalars.py
+++ b/test/test_scalars.py
@@ -5,7 +5,7 @@ import bson
 import bsonnumpy
 import numpy as np
 
-from test import TestFromBSON, millis, unittest
+from test import TestToNdarray, millis, unittest
 
 
 class TestToBSONScalars(unittest.TestCase):
@@ -70,27 +70,27 @@ class TestToBSONScalars(unittest.TestCase):
         #     bsonnumpy.ndarray_to_bson(array)
 
 
-class TestFromBSONScalars(TestFromBSON):
+class TestFromBSONScalars(TestToNdarray):
     def test_integer32_types(self):
         document = bson.SON([("0", 99), ("1", 88), ("2", 77), ("3", 66)])
         for np_type in [np.int32, np.uint32]:
-            self.compare_results(np_type, document, document)
+            self.compare_array_results(np_type, document, document)
 
     def test_integer64_types(self):
         document = bson.SON(
             [("0", 99), ("1", 88), ("2", 77)])
         for np_type in [np.int_, np.intc, np.intp, np.uint64, np.int64]:
-            self.compare_results(np_type, document, document)
+            self.compare_array_results(np_type, document, document)
 
     def test_bool(self):
         document = bson.SON([("0", True), ("1", False), ("2", True)])
-        self.compare_results(np.bool_, document, document)
+        self.compare_array_results(np.bool_, document, document)
 
     def test_float64_types(self):
         document = bson.SON(
             [("0", 99.99), ("1", 88.88), ("2", 77.77)])
         for np_type in [np.float_, np.float64]:
-            self.compare_results(np_type, document, document)
+            self.compare_array_results(np_type, document, document)
 
     def TODO_num_types(self):
         # np_types = [np.complex_, np.complex64, np.complex128, np.float32 ]
@@ -111,11 +111,11 @@ class TestFromBSONScalars(TestFromBSON):
     def test_string(self):
         document = bson.SON(
             [("0", b"string_0"), ("1", b"str1"), ("2", b"utf8-2")])
-        self.compare_results('<S10', document, document)
+        self.compare_array_results('<S10', document, document)
         document2 = bson.SON(
             [("0", b"st"), ("1", b"st"), ("2", b"ut")])
-        self.compare_results('<S2', document, document2)
-        self.compare_results('<S2', document2, document2)
+        self.compare_array_results('<S2', document, document2)
+        self.compare_array_results('<S2', document2, document2)
 
     def test_binary(self):
         document = bson.SON(

--- a/test/test_sequence.py
+++ b/test/test_sequence.py
@@ -418,7 +418,8 @@ class TestSequence2Ndarray(TestToNdarray):
         self.assertEqual(2, len(ndarray))
 
     def test_null(self):
-        data = bson._dict_to_bson({"x": None}, True, bson.DEFAULT_CODEC_OPTIONS)
+        data = bson._dict_to_bson(
+            {"x": None}, True, bson.DEFAULT_CODEC_OPTIONS)
         with self.assertRaises(bsonnumpy.error) as context:
             bsonnumpy.sequence_to_ndarray(iter([data]),
                                           np.dtype([('x', '<V10')]),


### PR DESCRIPTION
The refactor was getting to large, so I've included all my general bugfixes here and will create another pull request for the load_flexible_from_bson refactor (current only the nested_fix branch). There are two test cases in test_error_cases that currently skipped, as well as a the 'test_nested.py' file that tests the conditions that are currently not implemented. They can be summed up by saying our load_array function doesn't do any error checking and it doesn't support nested documents.

- Add a nicer debug helper for error cases where performance doesn't matter
- Audit error test cases
- Various bugfixes