### PR TITLE
Refactor named dtype loading functions

### DIFF
--- a/bson-numpy/bsonnumpy.c
+++ b/bson-numpy/bsonnumpy.c
@@ -178,7 +178,7 @@ _load_array_from_bson(bson_iter_t *it, PyArrayObject *ndarray, long offset,
         return 0;
     }
     PyObject* expected_length_obj = PyTuple_GetItem(shape, current_depth);
-    long expected_length = PyInt_AsLong(expected_length_obj);
+    long expected_length = PyLong_AsLong(expected_length_obj);
     int dimensions = (int) PyTuple_Size(shape);
 
     bson_iter_t sub_it;

--- a/bson-numpy/bsonnumpy.c
+++ b/bson-numpy/bsonnumpy.c
@@ -235,8 +235,8 @@ _load_array_from_bson(bson_iter_t *it, PyArrayObject *ndarray, long offset,
             i++;
         }
         /* Reset the rest of the coordinates to zero */
-        for (int p = current_depth; p < dimensions; p++) {
-            coordinates[p] = 0;
+        for (i = current_depth; i < dimensions; i++) {
+            coordinates[i] = 0;
         }
         return 1;
     }
@@ -580,6 +580,7 @@ _load_document_from_bson(bson_t *document, npy_intp *array_coordinates,
     PyArray_Descr *sub_dtype;
     PyObject *sub_dtype_obj, *offset_obj;
     Py_ssize_t i;
+    int sub_i;
 
     if (dtype->fields != NULL && dtype->fields != Py_None) {
         /* A field is described by a tuple composed of another data-type
@@ -667,7 +668,7 @@ _load_document_from_bson(bson_t *document, npy_intp *array_coordinates,
 
                 /* Indexing into ndarray with named fields returns a tuple
                  * that is nested as many levels as there are fields */
-                for (int sub_i = 0; sub_i < current_doc_depth + 1; sub_i++) {
+                for (sub_i = 0; sub_i < current_doc_depth + 1; sub_i++) {
                     npy_intp index = doc_coordinates[sub_i];
                     subarray_tuple = PyTuple_GetItem(subarray_tuple, index);
                 }

--- a/bson-numpy/bsonnumpy.c
+++ b/bson-numpy/bsonnumpy.c
@@ -551,62 +551,14 @@ _load_farray_from_bson(bson_iter_t *bsonit, npy_intp *coordinates,
             return _load_array_from_bson(
                     bsonit, ndarray, 0, coordinates, current_depth, dtype);
         } else {
+            /* TODO: implement support for arrays of nested documents */
             PyErr_SetString(BsonNumpyError,
                             "unhandled type: array of documents");
             return 0;
         }
 
-//V
-//        /* Loop through bson array */
-//        bson_iter_t sub_it;
-//        bson_iter_recurse(bsonit, &sub_it);
-//
-//        int i = 0;
-//        while (bson_iter_next(&sub_it)) {
-//            coordinates[current_depth-1] = i;
-//            printf("\tlooping through farray, coordinates=["); for (int i=0;i<number_dimensions;i++) { printf("%i,", coordinates[i]); }; printf("]\n");
-//            /* If we aren't at the base of the array, recur */
-//            if (current_depth < number_dimensions /* +1 or not?? */) {
-//                printf("\t\t RECUR:\n");
-//                _load_farray_from_bson(&sub_it, coordinates, ndarray, dtype, current_depth + 1);
-//            } else if(base_dtype->subarray != NULL) {
-//                //TODO: there's another subarray!!
-//            } else {
-//                printf("\t\t AT BASE OF ARRAY\n");
-//                /* Reached the end of the array */
-//                if (base_dtype->fields != NULL && base_dtype->fields != Py_None) {
-//                    printf("\t\t\t FOUND SUBDOC\n");
-//                    /* The array contains documents */
-//                    bson_t *sub_document;
-//                    uint32_t document_len;
-//                    const uint8_t *document_buffer;
-//
-//                    if (!BSON_ITER_HOLDS_DOCUMENT(&sub_it)) {
-//                        PyErr_SetString(BsonNumpyError,
-//                                        "invalid document: expected subdoc "
-//                                                "from dtype, got other type");
-//                        return 0;
-//                    }
-//
-//                    bson_iter_document(&sub_it, &document_len,
-//                                       &document_buffer);
-//                    sub_document = bson_new_from_data(document_buffer,
-//                                                      document_len);
-//                    debug("in load_farray, recurring on subdoc", NULL, sub_document);
-//                    _load_document_from_bson(sub_document, coordinates, ndarray, base_dtype, current_depth+1, 0);
-//
-//
-//                } else {
-//                    printf("\t\t\t FOUND SCALAR\n");
-//                    /* The array contains scalars */
-//                    _load_scalar_from_bson(&sub_it, ndarray, 0, coordinates, current_depth, base_dtype);
-//                }
-//            }
-//            i++;
-//        }
         return 1;
     }
-
     /* Called incorrectly */
     debug("_load_farray_from_bson called with a non-array dtype",
           (PyObject*)dtype, NULL);

--- a/test/test_arrays.py
+++ b/test/test_arrays.py
@@ -2,10 +2,11 @@ import bson
 import bsonnumpy
 import numpy as np
 
-from test import TestToNdarray
+from test import TestToNdarray, unittest
 
 
 class TestFromBSONArrays(TestToNdarray):
+    @unittest.skip("TODO: to be deleted in issue #27")
     def test_constant(self):
         document = bson.SON([("0", 99),
                              ("1", 88),
@@ -18,6 +19,7 @@ class TestFromBSONArrays(TestToNdarray):
         for b in range(len(result)):
             self.assertTrue(np.array_equal(document[str(b)], result[b]))
 
+    @unittest.skip("TODO: to be deleted in issue #27")
     def test_nd_len1_int(self):
         # arrays of len 1 become constants, except if top-level array is 1.
 
@@ -61,6 +63,7 @@ class TestFromBSONArrays(TestToNdarray):
         for b in range(len(result)):
             self.assertTrue(np.array_equal(document[str(b)], result[b]))
 
+    @unittest.skip("TODO: to be deleted in issue #27")
     def test_2d_int(self):
         document = bson.SON([("0", [9, 8]),
                              ("1", [6, 5]),
@@ -72,6 +75,7 @@ class TestFromBSONArrays(TestToNdarray):
         for b in range(len(result)):
             self.assertTrue(np.array_equal(document[str(b)], result[b]))
 
+    @unittest.skip("TODO: to be deleted in issue #27")
     def test_3d_int(self):
         document = bson.SON([("0", [[9, 9], [8, 8], [7, 7]]),
                              ("1", [[6, 6], [5, 5], [4, 4]]),
@@ -83,6 +87,7 @@ class TestFromBSONArrays(TestToNdarray):
         for b in range(len(result)):
             self.assertTrue(np.array_equal(document[str(b)], result[b]))
 
+    @unittest.skip("TODO: to be deleted in issue #27")
     def test_3d_len1(self):
         # arrays of length 1 are maintained when they are within another array
         document = bson.SON([("0",

--- a/test/test_error_cases.py
+++ b/test/test_error_cases.py
@@ -96,56 +96,66 @@ class TestErrors(TestToNdarray):
         with self.assertRaisesPattern(TypeError, r'\binteger\b'):
             bsonnumpy.sequence_to_ndarray(self.bson_docs, self.dtype, None)
 
-    def test_incorrect_sub_dtype(self):
-        son_docs = [
-            bson.SON(
-                [("x", bson.SON([("y", i), ("z", i)])),
-                 ("q", bson.SON([("y", i), ("z", i)]))]
-            ) for i in range(10)]
-        raw_docs = [bson._dict_to_bson(
-            doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
-        dtype = np.dtype([('y', np.int32), ('z', np.int32)])
-        dtype_sub = np.dtype([('x', dtype), ('q', dtype)])
+class TestDtypeErrors(TestToNdarray):
 
-        ndarray = np.array([((i, i), (i, i)) for i in range(10)],
-                           dtype=dtype_sub)
+    son_docs = [
+        bson.SON(
+            [("x", bson.SON([("y", i), ("z", i)])),
+             ("q", bson.SON([("y", i), ("z", i)]))]
+        ) for i in range(10)]
+    raw_docs = [bson._dict_to_bson(
+        doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
+    dtype = np.dtype([('y', np.int32), ('z', np.int32)])
+    dtype_sub = np.dtype([('x', dtype), ('q', dtype)])
 
+    ndarray = np.array([((i, i), (i, i)) for i in range(10)],
+                       dtype=dtype_sub)
+
+    if hasattr(unittest.TestCase, 'assertRaisesRegex'):
+        assertRaisesPattern = unittest.TestCase.assertRaisesRegex
+    else:
+        assertRaisesPattern = unittest.TestCase.assertRaisesRegexp
+
+    def test_correct_sub_dtype(self):
         # Correct dtype
-        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype_sub, 10)
-        self.assertTrue(np.array_equal(ndarray, res))
+        res = bsonnumpy.sequence_to_ndarray(self.raw_docs, self.dtype_sub, 10)
+        self.assertTrue(np.array_equal(self.ndarray, res))
 
+    def test_incorrect_sub_dtype2(self):
         # Top document missing key
         bad_doc = bson.SON(
             [("bad", bson.SON([("y", 0), ("z", 0)])),
              ("q", bson.SON([("y", 0), ("z", 0)]))])
 
-        bad_raw_docs = raw_docs[:9]
+        bad_raw_docs = self.raw_docs[:9]
         bad_raw_docs.append(
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
         with self.assertRaisesPattern(bsonnumpy.error,
                                       "document does not match dtype"):
-            bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype_sub, 10)
+            bsonnumpy.sequence_to_ndarray(bad_raw_docs, self.dtype_sub, 10)
 
+    def test_incorrect_sub_dtype3(self):
         # Sub document missing key
         bad_doc = bson.SON(
             [("x", bson.SON([("bad", 0), ("z", 0)])),
              ("q", bson.SON([("y", 0), ("z", 0)]))])
 
-        bad_raw_docs = raw_docs[:9]
+        bad_raw_docs = self.raw_docs[:9]
         bad_raw_docs.append(
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
         with self.assertRaisesPattern(bsonnumpy.error,
                                       "document does not match dtype"):
-            bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype_sub, 10)
+            bsonnumpy.sequence_to_ndarray(bad_raw_docs, self.dtype_sub, 10)
 
+    def test_incorrect_sub_dtype4(self):
         # Sub document not a document
         bad_doc = bson.SON(
             [("x", bson.SON([("y", 0), ("z", 0)])),
              ("q", 10)])
 
-        bad_raw_docs = raw_docs[:9]
+        bad_raw_docs = self.raw_docs[:9]
         bad_raw_docs.append(
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
@@ -153,14 +163,15 @@ class TestErrors(TestToNdarray):
                 bsonnumpy.error,
                 "invalid document: expected subdoc from dtype,"
                 " got other type"):
-            bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype_sub, 10)
+            bsonnumpy.sequence_to_ndarray(bad_raw_docs, self.dtype_sub, 10)
 
+    def test_incorrect_sub_dtype5(self):
         # Sub document not a document
         bad_doc = bson.SON(
             [("x", bson.SON([("y", 0), ("z", 0)])),
              ("q", [10, 11, 12])])
 
-        bad_raw_docs = raw_docs[:9]
+        bad_raw_docs = self.raw_docs[:9]
         bad_raw_docs.append(
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
@@ -168,69 +179,83 @@ class TestErrors(TestToNdarray):
                 bsonnumpy.error,
                 "invalid document: expected subdoc from dtype,"
                 " got other type"):
-            bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype_sub, 10)
+            bsonnumpy.sequence_to_ndarray(bad_raw_docs, self.dtype_sub, 10)
 
+    def test_incorrect_sub_dtype6(self):
         # Sub document extra key
         dtype2 = np.dtype([('y', np.int32), ('z', np.int32)])
         dtype_sub2 = np.dtype([('x', dtype2)])
 
         ndarray2 = np.array([((i, i),) for i in range(10)], dtype=dtype_sub2)
-        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype_sub2, 10)
+        res = bsonnumpy.sequence_to_ndarray(self.raw_docs, dtype_sub2, 10)
         self.assertTrue(np.array_equal(ndarray2, res))
 
         dtype3 = np.dtype([('y', np.int32)])
         dtype_sub3 = np.dtype([('x', dtype3), ('q', dtype3)])
         ndarray3 = np.array([((i,), (i,)) for i in range(10)],
                             dtype=dtype_sub3)
-        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype_sub3, 10)
+        res = bsonnumpy.sequence_to_ndarray(self.raw_docs, dtype_sub3, 10)
         self.assertTrue(np.array_equal(ndarray3, res))
 
-    def test_incorrect_sub_dtype_array(self):
-        son_docs = [
-            bson.SON(
-                [("x", [[i, i*2, i*3], [i*4, i*5, i*6]]),
-                 ("y", [[i*7, i*8, i*9], [i*10, i*11, i*12]])])
-            for i in ['a', 'b', 'c', 'd']]
-        raw_docs = [bson._dict_to_bson(
-            doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
-        dtype = np.dtype([('x', '2,3S13'), ('y', '2,3S13')])
+class TestArrayErrors(TestToNdarray):
 
-        ndarray = np.array(
-            [([[i, i*2, i*3], [i*4, i*5, i*6]],
-             ([[i*7, i*8, i*9], [i*10, i*11, i*12]]))
-                for i in ['a', 'b', 'c', 'd']], dtype=dtype)
+    if hasattr(unittest.TestCase, 'assertRaisesRegex'):
+        assertRaisesPattern = unittest.TestCase.assertRaisesRegex
+    else:
+        assertRaisesPattern = unittest.TestCase.assertRaisesRegexp
 
+    son_docs = [
+        bson.SON(
+            [("x", [[i, i*2, i*3], [i*4, i*5, i*6]]),
+             ("y", [[i*7, i*8, i*9], [i*10, i*11, i*12]])])
+        for i in ['a', 'b'
+            # , 'c', 'd'
+                  ]]
+    raw_docs = [bson._dict_to_bson(
+        doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
+    dtype = np.dtype([('x', '2,3S13'), ('y', '2,3S13')])
+
+    ndarray = np.array(
+        [([[i, i*2, i*3], [i*4, i*5, i*6]],
+         ([[i*7, i*8, i*9], [i*10, i*11, i*12]]))
+            for i in ['a', 'b',
+                      # 'c', 'd'
+                      ]], dtype=dtype)
+
+    def test_correct_sub_dtype_array(self):
         # Correct dtype
-        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)
-        self.assertTrue(np.array_equal(ndarray, res))
+        res = bsonnumpy.sequence_to_ndarray(self.raw_docs, self.dtype, 2)
+        print "expected", self.ndarray
+        print "actual", res
+        self.assertTrue(np.array_equal(self.ndarray, res))
 
+    def test_incorrect_sub_dtype_array1(self):
         # Top document missing key
         bad_doc = bson.SON(
             [("x", [['d'*1, 'd'*2, 'd'*3], ['d'*4, 'd'*5, 'd'*6]]),
              ("bad_key", [['d'*7, 'd'*7, 'd'*9], ['d'*10, 'd'*11, 'd'*12]])])
-        bad_raw_docs = raw_docs[:3]
+        bad_raw_docs = self.raw_docs[:3]
         bad_raw_docs.append(
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
         with self.assertRaisesPattern(bsonnumpy.error,
                                       "document does not match dtype"):
-            bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
+            bsonnumpy.sequence_to_ndarray(bad_raw_docs, self.dtype, 4)
 
+    def test_incorrect_sub_dtype_array2(self):
         # Top-level array not array
         bad_doc = bson.SON(
             [("x", [['d'*1, 'd'*2, 'd'*3], ['d'*4, 'd'*5, 'd'*6]]),
              ("y", 'not an array')])
-        bad_raw_docs = raw_docs[:3]
+        bad_raw_docs = self.raw_docs[:3]
         bad_raw_docs.append(
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
         with self.assertRaisesPattern(
                 bsonnumpy.error,
                 "invalid document: expected list from dtype, got other type"):
-            bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
+            bsonnumpy.sequence_to_ndarray(bad_raw_docs, self.dtype, 4)
 
-
-    @unittest.skip("not yet implemented")
-    def test_incorrect_sub_dtype2(self):
+    def test_incorrect_sub_dtype_array3(self):
         son_docs = [
             bson.SON(
                 [("x", [[i, i*2, i*3], [i*4, i*5, i*6]]),
@@ -260,51 +285,56 @@ class TestErrors(TestToNdarray):
         res = bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
         self.assertTrue(np.array_equal(ndarray, res))
 
+    def test_incorrect_sub_dtype_array4(self):
+
         # Sub array too long
         bad_doc = bson.SON(
             [("x", [['d'*1, 'd'*2, 'd'*3, 'd'*3],
                     ['d'*4, 'd'*5, 'd'*6, 'd'*3]]),
              ("y", [['d'*7, 'd'*8, 'd'*9, 'd'*3],
                     ['d'*10, 'd'*11, 'd'*12, 'd'*3]])])
-        bad_raw_docs = raw_docs[:3]
+        bad_raw_docs = self.raw_docs[:3]
         bad_raw_docs.append(
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
-        res = bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
-        self.assertTrue(np.array_equal(ndarray, res))
+        res = bsonnumpy.sequence_to_ndarray(bad_raw_docs, self.dtype, 4)
+        self.assertTrue(np.array_equal(self.ndarray, res))
 
+    def test_incorrect_sub_dtype_array5(self):
         # TODO: not checking type
         # Sub array not array
         bad_doc = bson.SON(
             [("x", [['d'*1, 'd'*2, 'd'*3], ['d'*4, 'd'*5, 'd'*6]]),
              ("y", ['not an array', ['d'*10, 'd'*11, 'd'*12]])])
-        bad_raw_docs = raw_docs[:3]
+        bad_raw_docs = self.raw_docs[:3]
         bad_raw_docs.append(
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
         with self.assertRaisesPattern(bsonnumpy.error,
                                       "document does not match dtype"):
-            bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
+            bsonnumpy.sequence_to_ndarray(bad_raw_docs, self.dtype, 4)
 
+    def test_incorrect_sub_dtype_array6(self):
         # TODO: segfaults
         # Top-level array too short
         bad_doc = bson.SON(
             [("x", [['d'*1, 'd'*2, 'd'*3]]),
              ("y", [['d'*7, 'd'*8, 'd'*9]])])
-        bad_raw_docs = raw_docs[:3]
+        bad_raw_docs = self.raw_docs[:3]
         bad_raw_docs.append(
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
 
         with self.assertRaisesPattern(bsonnumpy.error,
                                       "document does not match dtype"):
-            bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
+            bsonnumpy.sequence_to_ndarray(bad_raw_docs, self.dtype, 4)
 
+    def test_incorrect_sub_dtype_array7(self):
         # TODO: currently just leaves last element empty
         # Sub array too short
         bad_doc = bson.SON(
             [("x", [['d'*1, 'd'*2], ['d'*4, 'd'*5]]),
              ("y", [['d'*7, 'd'*8], ['d'*10, 'd'*11]])])
-        bad_raw_docs = raw_docs[:3]
+        bad_raw_docs = self.raw_docs[:3]
         bad_raw_docs.append(
             bson._dict_to_bson(bad_doc, False, bson.DEFAULT_CODEC_OPTIONS))
-        res = bsonnumpy.sequence_to_ndarray(bad_raw_docs, dtype, 4)
-        self.assertTrue(np.array_equal(ndarray, res))
+        res = bsonnumpy.sequence_to_ndarray(bad_raw_docs, self.dtype, 4)
+        self.assertTrue(np.array_equal(self.ndarray, res))

--- a/test/test_error_cases.py
+++ b/test/test_error_cases.py
@@ -96,7 +96,8 @@ class TestErrors(TestToNdarray):
         with self.assertRaisesPattern(TypeError, r'\binteger\b'):
             bsonnumpy.sequence_to_ndarray(self.bson_docs, self.dtype, None)
 
-class TestDtypeErrors(TestToNdarray):
+
+class TestSubdocErrors(TestToNdarray):
 
     son_docs = [
         bson.SON(
@@ -196,6 +197,7 @@ class TestDtypeErrors(TestToNdarray):
                             dtype=dtype_sub3)
         res = bsonnumpy.sequence_to_ndarray(self.raw_docs, dtype_sub3, 10)
         self.assertTrue(np.array_equal(ndarray3, res))
+
 
 class TestArrayErrors(TestToNdarray):
 

--- a/test/test_error_cases.py
+++ b/test/test_error_cases.py
@@ -2,7 +2,7 @@ import bson
 import bsonnumpy
 import numpy as np
 
-from test import client_context, TestToNdarray, unittest
+from test import TestToNdarray, unittest
 
 
 class TestErrors(TestToNdarray):
@@ -138,7 +138,7 @@ class TestErrors(TestToNdarray):
         self.assertEqual(ndarray[0]["x"].tobytes(), b"abc\0")
 
 
-class TestSubdocErrors(TestToNdarray):
+class TestDocErrors(TestToNdarray):
 
     son_docs = [
         bson.SON(
@@ -176,7 +176,7 @@ class TestSubdocErrors(TestToNdarray):
                                       "document does not match dtype"):
             bsonnumpy.sequence_to_ndarray(bad_raw_docs, self.dtype_sub, 10)
 
-    def test_incorrect_sub_dtype1a(self):
+    def test_incorrect_sub_dtype2(self):
         # Top document has extra key
         data = bson._dict_to_bson({"x": 12, "y": 13}, True,
                                   bson.DEFAULT_CODEC_OPTIONS)
@@ -190,7 +190,7 @@ class TestSubdocErrors(TestToNdarray):
         with self.assertRaises(ValueError):
             ndarray[0]["x"]
 
-    def test_incorrect_sub_dtype2(self):
+    def test_incorrect_sub_dtype3(self):
         # Sub document missing key
         bad_doc = bson.SON(
             [("x", bson.SON([("bad", 0), ("z", 0)])),
@@ -204,7 +204,7 @@ class TestSubdocErrors(TestToNdarray):
                                       "document does not match dtype"):
             bsonnumpy.sequence_to_ndarray(bad_raw_docs, self.dtype_sub, 10)
 
-    def test_incorrect_sub_dtype3(self):
+    def test_incorrect_sub_dtype4(self):
         # Sub document not a document
         bad_doc = bson.SON(
             [("x", bson.SON([("y", 0), ("z", 0)])),
@@ -234,7 +234,7 @@ class TestSubdocErrors(TestToNdarray):
                 " got other type"):
             bsonnumpy.sequence_to_ndarray(bad_raw_docs, self.dtype_sub, 10)
 
-    def test_incorrect_sub_dtype4(self):
+    def test_incorrect_sub_dtype5(self):
         # Sub document extra key
         dtype2 = np.dtype([('y', np.int32), ('z', np.int32)])
         dtype_sub2 = np.dtype([('x', dtype2)])

--- a/test/test_nested.py
+++ b/test/test_nested.py
@@ -31,8 +31,6 @@ class TestNested(TestToNdarray):
         # Correct dtype
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 2)
 
-        print "expected", ndarray
-        print "actual", res
         self.assertTrue(np.array_equal(ndarray, res))
 
     def test_array_scalar_load0(self):
@@ -50,11 +48,9 @@ class TestNested(TestToNdarray):
         # Correct dtype
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 2)
 
-        print "expected", ndarray
-        print "actual", res
         self.assertTrue(np.array_equal(ndarray, res))
 
-    # @unittest.skip("not yet implemented")
+    @unittest.skip("not yet implemented")
     def test_array_scalar_load1(self):
         # Test arrays with documents as elements
 
@@ -75,7 +71,7 @@ class TestNested(TestToNdarray):
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 2)
         self.assertTrue(np.array_equal(ndarray, res))
 
-    # @unittest.skip("not yet implemented")
+    @unittest.skip("not yet implemented")
     def test_array_scalar_load2(self):
         # Test sub arrays with documents as elements
         son_docs = [
@@ -103,8 +99,6 @@ class TestNested(TestToNdarray):
 
         # Correct dtype
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 2)
-        print "expected", ndarray
-        print "actual", res
         self.assertTrue(np.array_equal(ndarray, res))
 
     @unittest.skip("not yet implemented")

--- a/test/test_nested.py
+++ b/test/test_nested.py
@@ -26,7 +26,7 @@ class TestNested(TestToNdarray):
             doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
         dtype = np.dtype([('x', '4int32')])
 
-        ndarray = np.array([([i, i,i, i],) for i in range(2, 4)], dtype)
+        ndarray = np.array([([i, i, i, i],) for i in range(2, 4)], dtype)
 
         # Correct dtype
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 2)
@@ -44,7 +44,8 @@ class TestNested(TestToNdarray):
             doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
         dtype = np.dtype([('x', '(3,2)int32')])
 
-        ndarray = np.array([([[i, i] for _ in range(3)],) for i in range(2, 4)], dtype)
+        ndarray = np.array(
+            [([[i, i] for _ in range(3)],) for i in range(2, 4)], dtype)
 
         # Correct dtype
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 2)
@@ -52,7 +53,6 @@ class TestNested(TestToNdarray):
         print "expected", ndarray
         print "actual", res
         self.assertTrue(np.array_equal(ndarray, res))
-
 
     # @unittest.skip("not yet implemented")
     def test_array_scalar_load1(self):
@@ -97,9 +97,9 @@ class TestNested(TestToNdarray):
         sub_dtype = np.dtype((sub_sub_dtype, 2))
         dtype = np.dtype([('x', sub_dtype)])
 
-        ndarray = np.array([[([(i, i), (-i, -i)],),
-                             ([(i, i), (-i, -i)],)] for i in range(2, 4)], dtype)
-
+        ndarray = np.array(
+            [[([(i, i), (-i, -i)],),
+              ([(i, i), (-i, -i)],)] for i in range(2, 4)], dtype)
 
         # Correct dtype
         res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 2)

--- a/test/test_nested.py
+++ b/test/test_nested.py
@@ -16,7 +16,45 @@ class TestNested(TestToNdarray):
     else:
         assertRaisesPattern = unittest.TestCase.assertRaisesRegexp
 
-    @unittest.skip("not yet implemented")
+    # @unittest.skip("not yet implemented")
+    def test_array_scalar_load00(self):
+        # Test arrays with documents as elements
+
+        son_docs = [
+            bson.SON([('x', [i, i, i, i])]) for i in range(2, 4)]
+        raw_docs = [bson._dict_to_bson(
+            doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
+        dtype = np.dtype([('x', '4int32')])
+
+        ndarray = np.array([([i, i,i, i],) for i in range(2, 4)], dtype)
+
+        # Correct dtype
+        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 2)
+
+        print "expected", ndarray
+        print "actual", res
+        self.assertTrue(np.array_equal(ndarray, res))
+
+    def test_array_scalar_load0(self):
+        # Test arrays with documents as elements
+
+        son_docs = [
+            bson.SON([('x', [[i, i] for _ in range(3)])]) for i in range(2, 4)]
+        raw_docs = [bson._dict_to_bson(
+            doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
+        dtype = np.dtype([('x', '(3,2)int32')])
+
+        ndarray = np.array([([[i, i] for _ in range(3)],) for i in range(2, 4)], dtype)
+
+        # Correct dtype
+        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 2)
+
+        print "expected", ndarray
+        print "actual", res
+        self.assertTrue(np.array_equal(ndarray, res))
+
+
+    # @unittest.skip("not yet implemented")
     def test_array_scalar_load1(self):
         # Test arrays with documents as elements
 
@@ -25,18 +63,19 @@ class TestNested(TestToNdarray):
                 [('x', [
                     bson.SON([('a', i), ('b', i)]),
                     bson.SON([('a', -i), ('b', -i)])
-                ])]) for i in range(10)]
+                ])]) for i in range(2, 4)]
         raw_docs = [bson._dict_to_bson(
             doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
         sub_dtype = np.dtype(([('a', 'int32'), ('b', 'int32')], 2))
         dtype = np.dtype([('x', sub_dtype)])
 
-        ndarray = np.array([([(i, i), (-i, -i)],) for i in range(10)], dtype)
+        ndarray = np.array([([(i, i), (-i, -i)],) for i in range(2, 4)], dtype)
+
         # Correct dtype
-        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)
+        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 2)
         self.assertTrue(np.array_equal(ndarray, res))
 
-    @unittest.skip("not yet implemented")
+    # @unittest.skip("not yet implemented")
     def test_array_scalar_load2(self):
         # Test sub arrays with documents as elements
         son_docs = [
@@ -51,7 +90,7 @@ class TestNested(TestToNdarray):
                         bson.SON([('c', -i), ('d', -i)])
                     ],
 
-                ])]) for i in range(10)]
+                ])]) for i in range(2, 4)]
         raw_docs = [bson._dict_to_bson(
             doc, False, bson.DEFAULT_CODEC_OPTIONS) for doc in son_docs]
         sub_sub_dtype = np.dtype(([('a', 'int32'), ('b', 'int32')], 2))
@@ -59,10 +98,13 @@ class TestNested(TestToNdarray):
         dtype = np.dtype([('x', sub_dtype)])
 
         ndarray = np.array([[([(i, i), (-i, -i)],),
-                             ([(i, i), (-i, -i)],)] for i in range(10)], dtype)
+                             ([(i, i), (-i, -i)],)] for i in range(2, 4)], dtype)
+
 
         # Correct dtype
-        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 4)
+        res = bsonnumpy.sequence_to_ndarray(raw_docs, dtype, 2)
+        print "expected", ndarray
+        print "actual", res
         self.assertTrue(np.array_equal(ndarray, res))
 
     @unittest.skip("not yet implemented")

--- a/test/test_sequence.py
+++ b/test/test_sequence.py
@@ -330,11 +330,11 @@ class TestSequenceNestedArray(TestToNdarray):
     def test_nested_array3x2d(self):
         # 3x nested documents with 2d array
         docs = [
-            {'x': {'y': {'z': [
-                    [100 + i, 100 - i, 100],
-                    [1 * i, 2 * i, 3 * i],
-                    [4 * i, 5 * i, 6 * i],
-                    [7 * i, 8 * i, 9 * i]]}}} for i in range(10)]
+            {'x': {'y': {
+                'z': [[100 + i, 100 - i, 100],
+                      [1 * i, 2 * i, 3 * i],
+                      [4 * i, 5 * i, 6 * i],
+                      [7 * i, 8 * i, 9 * i]]}}} for i in range(10)]
         dtype0 = np.dtype([('z', '(4,3)int32')])
         dtype1 = np.dtype([('y', dtype0)])
         dtype = np.dtype([('x', dtype1)])
@@ -344,14 +344,14 @@ class TestSequenceNestedArray(TestToNdarray):
     def test_nested_array3x2d_mixed(self):
         # 3x nested documents with 2d array and other fields
         docs = [
-            {'x': {'y': {'z': [
-                [100 + i, 100 - i, 100],
-                [1 * i, 2 * i, 3 * i],
-                [4 * i, 5 * i, 6 * i],
-                [7 * i, 8 * i, 9 * i]],
-            'z2': "this is a string!"},
-            'y2': {'a': "a different doc string"}},
-            'x2': [1, 2, 3]} for i in range(10)]
+            {'x': {'y': {
+                'z': [[100 + i, 100 - i, 100],
+                      [1 * i, 2 * i, 3 * i],
+                      [4 * i, 5 * i, 6 * i],
+                      [7 * i, 8 * i, 9 * i]],
+                'z2': "this is a string!"},
+                'y2': {'a': "a different doc string"}},
+                'x2': [1, 2, 3]} for i in range(10)]
         dtype2 = np.dtype([('a', 'S26')])
         dtype0 = np.dtype([('z', '(4,3)int32'), ('z2', 'S17')])
         dtype1 = np.dtype([('y', dtype0), ('y2', dtype2)])

--- a/test/test_sequence.py
+++ b/test/test_sequence.py
@@ -252,7 +252,6 @@ class TestSequenceDoc(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype)
 
 
-
 class TestSequenceNestedArray(TestToNdarray):
     @client_context.require_connected
     def test_collection_sub_subarrays(self):

--- a/test/test_sequence.py
+++ b/test/test_sequence.py
@@ -14,7 +14,7 @@ from test import client_context, millis, unittest, TestToNdarray
 
 class TestSequenceFlat(TestToNdarray):
     @client_context.require_connected
-    def test_collection_flexible_int32(self):
+    def test_int32(self):
         docs = [{"x": i, "y": 10 - i} for i in range(10)]
         dtype = np.dtype([('x', np.int32), ('y', np.int32)])
         self.make_mixed_collection_test(docs, dtype)
@@ -22,7 +22,7 @@ class TestSequenceFlat(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype)
 
     @client_context.require_connected
-    def test_collection_flexible_int64(self):
+    def test_int64(self):
         docs = [{"x": i, "y": 2**63 - 1 - i} for i in range(10)]
         dtype = np.dtype([('x', np.int64), ('y', np.int64)])
         self.make_mixed_collection_test(docs, dtype)
@@ -30,7 +30,7 @@ class TestSequenceFlat(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype)
 
     @client_context.require_connected
-    def test_collection_flexible_objectid(self):
+    def test_objectid(self):
         docs = [{"x": bson.ObjectId()} for _ in range(10)]
         dtype = np.dtype([('x', '<V12')])
 
@@ -49,13 +49,13 @@ class TestSequenceFlat(TestToNdarray):
             self.assertEqual(document["x"].binary, row["x"].tobytes())
 
     @client_context.require_connected
-    def test_collection_flexible_bool(self):
+    def test_bool(self):
         docs = [{"x": True}, {"x": False}]
         dtype = np.dtype([('x', np.bool)])
         self.make_mixed_collection_test(docs, dtype)
 
     @client_context.require_connected
-    def test_collection_flexible_datetime(self):
+    def test_datetime(self):
         docs = [{"x": datetime.datetime(1970, 1, 1)},
                 {"x": datetime.datetime(1980, 1, 1)},
                 {"x": datetime.datetime(1990, 1, 1)}]
@@ -78,19 +78,19 @@ class TestSequenceFlat(TestToNdarray):
                 row["x"])
 
     @client_context.require_connected
-    def test_collection_flexible_double(self):
+    def test_double(self):
         docs = [{"x": math.pi}, {"x": math.pi ** 2}]
         dtype = np.dtype([('x', np.double)])
         self.make_mixed_collection_test(docs, dtype)
 
     @client_context.require_connected
-    def test_collection_flexible_binary(self):
+    def test_binary(self):
         docs = [{"x": bson.Binary(b"asdf")}]
         dtype = np.dtype([('x', np.dtype("<V10"))])
         self.make_mixed_collection_test(docs, dtype)
 
     @client_context.require_connected
-    def test_collection_flexible_mixed_scalar(self):
+    def test_mixed_scalar(self):
         docs = [{"x": i, "y": random.choice(string.ascii_lowercase) * 11} for i
                 in range(10)]
         dtype = np.dtype([('x', np.int32), ('y', 'S11')])
@@ -98,11 +98,15 @@ class TestSequenceFlat(TestToNdarray):
         dtype = np.dtype([('y', 'S11'), ('x', np.int32)])
         self.make_mixed_collection_test(docs, dtype)
 
+    def test_void(self):
+        # TODO: test for types that are 'V'
+        pass
+
 
 class TestSequenceArray(TestToNdarray):
     @client_context.require_connected
-    def test_collection_flexible_subarray1(self):
-        # 2d subarray
+    def test_subarray1d(self):
+        # 1d subarray
         docs = [{"x": [1 + i, -i - 1], "y": [i, -i]} for i in range(5)]
         dtype = np.dtype([('x', '2int32'), ('y', '2int32')])
         self.make_mixed_collection_test(docs, dtype)
@@ -110,20 +114,20 @@ class TestSequenceArray(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype)
 
     @client_context.require_connected
-    def test_collection_flexible_subarray2(self):
-        # 3d subarray
-        docs = [{"x": [[i, i + 1, i + 2],
-                       [-i, -i - 1, -i - 2],
-                       [100 * i, 100 * i + 1, 100 * i + 2],
-                       [0, 1, 2]],
-                 "y": "string!!!"} for i in range(5)]
+    def test_subarray2d(self):
+        # 2d subarray
+        docs = [{"x": [[i + 0, i + 1, i + 2],
+                       [i + 3, i + 4, i + 5],
+                       [i + 6, i + 7, i + 8],
+                       [i + 9, i + 10, i + 11]],
+                 "y": "string!!" + str(i)} for i in range(2, 4)]
         dtype = np.dtype([('x', "(4,3)int32"), ('y', 'S10')])
         self.make_mixed_collection_test(docs, dtype)
         dtype = np.dtype([('y', 'S10'), ('x', "(4,3)int32")])
         self.make_mixed_collection_test(docs, dtype)
 
     @client_context.require_connected
-    def test_collection_flexible_subarray3(self):
+    def test_subarray3d(self):
         # 3d subarray
         docs = []
         for i in range(5):
@@ -154,7 +158,7 @@ class TestSequenceArray(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype)
 
     @client_context.require_connected
-    def test_collection_flexible_subarray2_mixed1(self):
+    def test_subarray2d2(self):
         # 3d subarray
         docs = [{"x": [[i, i + 1, i + 2],
                        [-i, -i - 1, -i - 2],
@@ -166,7 +170,7 @@ class TestSequenceArray(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype)
 
     @client_context.require_connected
-    def test_collection_flexible_mixed(self):
+    def test_mixed(self):
         docs = [{"x": [i, -i], "y": random.choice(string.ascii_lowercase) * 11,
                  "z": bson.Binary(b'foobar')} for i in range(10)]
         dtype = np.dtype([('x', '2int32'), ('y', 'S11'), ('z', 'V12')])

--- a/test/test_sequence.py
+++ b/test/test_sequence.py
@@ -120,7 +120,7 @@ class TestSequenceArray(TestToNdarray):
                        [i + 3, i + 4, i + 5],
                        [i + 6, i + 7, i + 8],
                        [i + 9, i + 10, i + 11]],
-                 "y": "string!!" + str(i)} for i in range(2, 4)]
+                 "y": "string!!" + str(i)} for i in range(10)]
         dtype = np.dtype([('x', "(4,3)int32"), ('y', 'S10')])
         self.make_mixed_collection_test(docs, dtype)
         dtype = np.dtype([('y', 'S10'), ('x', "(4,3)int32")])
@@ -183,7 +183,7 @@ class TestSequenceArray(TestToNdarray):
 
 class TestSequenceDoc(TestToNdarray):
     @client_context.require_connected
-    def test_collection_sub1(self):
+    def test_subdoc1(self):
         # nested documents
         docs = [{'x': {'y': 100 + i}} for i in range(10)]
         dtype = np.dtype([('y', np.int32)])
@@ -191,7 +191,7 @@ class TestSequenceDoc(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype_sub)
 
     @client_context.require_connected
-    def test_collection_sub2(self):
+    def test_subdoc2(self):
         # sub-doc has multiple fields
         docs = [{'x': {'y': 100 + i, 'z': i}} for i in range(10)]
         dtype = np.dtype([('y', np.int32), ('z', np.int32)])
@@ -199,7 +199,7 @@ class TestSequenceDoc(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype_sub)
 
     @client_context.require_connected
-    def test_collection_sub3(self):
+    def test_subdoc3(self):
         # doc has multiple fields
         docs = [{'x': {'y': 100 + i}, 'q': {'y': -i}} for i in range(10)]
         dtype = np.dtype([('y', np.int32)])
@@ -207,7 +207,7 @@ class TestSequenceDoc(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype_sub)
 
     @client_context.require_connected
-    def test_collection_sub4(self):
+    def test_subdoc4(self):
         # doc and subdoc have multiple fields
         docs = [{'x': {'y': 100 + i, 'z': i}, 'q': {'y': -i, 'z': 100 - i}} for
                 i in range(10)]
@@ -219,7 +219,7 @@ class TestSequenceDoc(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype_sub)
 
     @client_context.require_connected
-    def test_collection_sub4_mixed(self):
+    def test_subdoc4_mixed(self):
         docs = [{'x': {'y': str(10 + i) * i, 'z': i},
                  'q': {'y': str(i) * i, 'z': 100 - i}} for i in range(10)]
         dtype = np.dtype([('y', 'S110'), ('z', np.int32)])
@@ -230,7 +230,7 @@ class TestSequenceDoc(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype_sub)
 
     @client_context.require_connected
-    def test_collection_sub5(self):
+    def test_subdoc5(self):
         # 3x nested documents
         docs = [{'x': {'y': {'z': 100 + i}}} for i in range(10)]
         dtype0 = np.dtype([('z', np.int32)])
@@ -239,7 +239,7 @@ class TestSequenceDoc(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype)
 
     @client_context.require_connected
-    def test_collection_sub6(self):
+    def test_subdoc6(self):
         # 3x nested documents
         docs = [{'x': {'y': {'z': i,
                              'z2': "this is a string!"},
@@ -258,9 +258,11 @@ class TestSequenceDoc(TestToNdarray):
 
 class TestSequenceNestedArray(TestToNdarray):
     @client_context.require_connected
-    def test_collection_sub_subarrays(self):
+    def test_nested_array(self):
         docs = [
-            {'x': {'y': [100 + i, 100, i], 'y1': (i + 1) * 10}, 'x1': i + 5}
+            {'x': {'y': [100 + i, 100, i],
+                   'y1': (i + 1) * 10},
+             'x1': i + 5}
             for i in range(10)]
 
         dtype = np.dtype([('y', '3int32'), ('y1', 'int32')])
@@ -271,9 +273,10 @@ class TestSequenceNestedArray(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype_sub)
 
     @client_context.require_connected
-    def test_collection_sub_subarrays2(self):
+    def test_nested_array2x(self):
         docs = [{'x': {'y': [[100 + i, 100, i],
-                             [i, i + 1, i + 2]], 'y1': (i + 1) * 10},
+                             [i, i + 1, i + 2]],
+                       'y1': (i + 1) * 10},
                  'x1': i + 5} for i in range(10)]
         dtype = np.dtype([('y', '(2,3)int32'), ('y1', 'int32')])
         dtype_sub = np.dtype([('x', dtype), ('x1', 'int32')])
@@ -283,9 +286,10 @@ class TestSequenceNestedArray(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype_sub)
 
     @client_context.require_connected
-    def test_collection_sub_subarrays3(self):
+    def test_nested_array2x_mixed(self):
         docs = [{'x': {'y': [[100 + i, 100, i],
-                             [i, i + 1, i + 2]], 'y1': (i + 1) * 10},
+                             [i, i + 1, i + 2]],
+                       'y1': (i + 1) * 10},
                  'x1': [[[i + 5, i + 6], [i + 7, i + 8]],
                         [[i + 9, i + 10], [i + 11, i + 12]]]} for i in
                 range(10)]
@@ -297,7 +301,7 @@ class TestSequenceNestedArray(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype_sub)
 
     @client_context.require_connected
-    def test_collection_sub_subarrays4(self):
+    def test_nested_array2x_mixed2(self):
         docs = [{'x': {'y': [[100 + i, 100, i],
                              [i, i + 1, i + 2]],
                        'y1': (i + 1) * 10,
@@ -313,37 +317,41 @@ class TestSequenceNestedArray(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype_sub)
 
     @client_context.require_connected
-    def test_collection_sub4_array(self):
+    def test_nested_array3x(self):
         # 3x nested documents
-        docs = [{'x': {'y': {'z': [100 + i, 100 - i]}}} for i in range(10)]
+        docs = [{'x': {'y': {'z': [
+            100 + i, 100 - i]}}} for i in range(10)]
         dtype0 = np.dtype([('z', '2int32')])
         dtype1 = np.dtype([('y', dtype0)])
         dtype = np.dtype([('x', dtype1)])
         self.make_mixed_collection_test(docs, dtype)
 
     @client_context.require_connected
-    def test_collection_sub4_array(self):
-        # 3x nested documents
-        docs = [{'x': {'y': {'z': [
-            [100 + i, 100 - i, 100],
-            [1 * i, 2 * i, 3 * i],
-            [4 * i, 5 * i, 6 * i],
-            [7 * i, 8 * i, 9 * i]]}}} for i in range(10)]
+    def test_nested_array3x2d(self):
+        # 3x nested documents with 2d array
+        docs = [
+            {'x': {'y': {'z': [
+                    [100 + i, 100 - i, 100],
+                    [1 * i, 2 * i, 3 * i],
+                    [4 * i, 5 * i, 6 * i],
+                    [7 * i, 8 * i, 9 * i]]}}} for i in range(10)]
         dtype0 = np.dtype([('z', '(4,3)int32')])
         dtype1 = np.dtype([('y', dtype0)])
         dtype = np.dtype([('x', dtype1)])
         self.make_mixed_collection_test(docs, dtype)
 
     @client_context.require_connected
-    def test_collection_sub4_array2(self):
-        # 3x nested documents
-        docs = [{'x': {'y': {'z': [[100 + i, 100 - i, 100],
-                                   [1 * i, 2 * i, 3 * i],
-                                   [4 * i, 5 * i, 6 * i],
-                                   [7 * i, 8 * i, 9 * i]],
-                             'z2': "this is a string!"},
-                       'y2': {'a': "a different doc string"}},
-                 'x2': [1, 2, 3]} for i in range(10)]
+    def test_nested_array3x2d_mixed(self):
+        # 3x nested documents with 2d array and other fields
+        docs = [
+            {'x': {'y': {'z': [
+                [100 + i, 100 - i, 100],
+                [1 * i, 2 * i, 3 * i],
+                [4 * i, 5 * i, 6 * i],
+                [7 * i, 8 * i, 9 * i]],
+            'z2': "this is a string!"},
+            'y2': {'a': "a different doc string"}},
+            'x2': [1, 2, 3]} for i in range(10)]
         dtype2 = np.dtype([('a', 'S26')])
         dtype0 = np.dtype([('z', '(4,3)int32'), ('z2', 'S17')])
         dtype1 = np.dtype([('y', dtype0), ('y2', dtype2)])
@@ -355,7 +363,7 @@ class TestSequenceNestedArray(TestToNdarray):
         self.make_mixed_collection_test(docs, dtype)
 
     @client_context.require_connected
-    def test_collection_sub_many(self):
+    def test_nested_array_complicated(self):
         num = 3
         docs = [{} for _ in range(num)]
 


### PR DESCRIPTION
Lots of bugfixes and neater code. 

- Separated subdocument and subarray loading functions, remove load_flexible.
- Removed the ability to load arrays as scalars as there was no error checking, and since bson_to_ndarray is going away, we'll never use it.
- skip bson_to_ndarray tests, will be moved to sequence tests in #27 
- Add error and type checking to array and document loading
- Add better error messages and debug statements for errors
- Reorganize tests and add comments