### PR TITLE
BSON-NumPy is superseded by PyMongoArrow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,13 @@
 ==========
 BSON-NumPy
 ==========
+
+MongoDB, Inc. has stopped development of BSON-NumPy and this project has been superseded by
+`PyMongoArrow <https://github.com/mongodb-labs/mongo-arrow/tree/main/bindings/python>`_. In addition
+to NumPy arrays, **PyMongoArrow** also supports direct conversion of MongoDB query results to
+Pandas DataFrames and Apache Arrow Tables, amongst other features. See the project
+`documentation <https://mongo-arrow.readthedocs.io/>`_ to get started with **PyMongoArrow**.
+
 :Info: See `the mongo site <http://www.mongodb.org>`_ for more information. See `GitHub <http://github.com/mongodb/bson-numpy>`_ for the latest source.
 :Author: Anna Herlihy
 :Maintainer: The MongoDB Python Team

--- a/doc/_static/warnDeprecated.js
+++ b/doc/_static/warnDeprecated.js
@@ -1,0 +1,20 @@
+"use strict";
+
+function warnProjectDeprecated() {
+  var warning = document.createElement('div');
+  warning.setAttribute('class', 'admonition danger');
+  warning.innerHTML = "<p class='first admonition-title'>Attention</p> " +
+    "<p class='last'> " +
+    "BSON-NumPy has been superseded by <a href='https://mongo-arrow.readthedocs.io/'>PyMongoArrow</a> " +
+    "and is no longer actively developed. In addition to NumPy arrays, <strong>PyMongoArrow</strong> " +
+    "also supports direct conversion of MongoDB query results to Pandas DataFrames and Apache Arrow Tables. " +
+    "Users are encouraged to migrate their BSON-NumPy workloads to PyMongoArrow for continued support." +
+    "</p>";
+
+  var parent = document.querySelector('div.body')
+    || document.querySelector('div.document')
+    || document.body;
+  parent.insertBefore(warning, parent.firstChild);
+}
+
+document.addEventListener('DOMContentLoaded', warnProjectDeprecated);

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -105,6 +105,9 @@ html_theme = 'alabaster'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_js_files = [
+    'warnDeprecated.js',
+]
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ def setup_package():
         license="Apache License, Version 2.0",
         python_requires=">=3.5",
         classifiers=[
-            "Development Status :: 3 - Alpha",
+            "Development Status :: 7 - Inactive",
             "Intended Audience :: Developers",
             "License :: OSI Approved :: Apache Software License",
             "Operating System :: MacOS :: MacOS X",


### PR DESCRIPTION
What it looks like in action: 

![image](https://user-images.githubusercontent.com/5883388/116754958-7c58b200-a9be-11eb-9c4c-80304d30775a.png)
